### PR TITLE
FIX: Encoding used by requests

### DIFF
--- a/geizhals/core.py
+++ b/geizhals/core.py
@@ -52,7 +52,7 @@ def send_request(url):
     if not successful_connection:
         raise HTTPLimitedException("Geizhals blocked us temporarily!")
 
-    html_str = r.content.decode()
+    html_str = r.text
     logger.debug("HTML content length: {} - status code: {}".format(len(html_str), r.status_code))
     html_str = html.unescape(html_str)
     return html_str


### PR DESCRIPTION
I used to get the byte content of the request and decode it to a unicode string. But I found that using r.text is a much more efficient solution to this. I hope that this won't introduce any bug, but it worked on my machine (tm).
