### PR TITLE
Added minimal version of docker-compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.3"
+services:
+  geizhalsbot:
+    container_name: ghbot
+    restart: always
+    volumes:
+      - "/path/to/logs/:/usr/src/bot/logs"
+      - "/path/to/config.py:/usr/src/bot/config.py"
+    build: .


### PR DESCRIPTION
This adds the minimum working version of a `docker-compose.yml` as mentioned in #62 .

You can use it by typing `docker-compose up` and it builds and sets everything up.


In the `docker-compose.yml` you still have to set the path to your config.py and the logs folder.