### PR TITLE
FIX: Usage of wrong 'user' object

### DIFF
--- a/geizhals/tests/example.html
+++ b/geizhals/tests/example.html
@@ -11,29 +11,25 @@
         background-color: #f0f0f2;
         margin: 0;
         padding: 0;
-        font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 
     }
     div {
         width: 600px;
         margin: 5em auto;
-        padding: 50px;
-        background-color: #fff;
-        border-radius: 1em;
+        padding: 2em;
+        background-color: #fdfdff;
+        border-radius: 0.5em;
+        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
     }
     a:link, a:visited {
         color: #38488f;
         text-decoration: none;
     }
     @media (max-width: 700px) {
-        body {
-            background-color: #fff;
-        }
         div {
-            width: auto;
             margin: 0 auto;
-            border-radius: 0;
-            padding: 1em;
+            width: auto;
         }
     }
     </style>
@@ -42,9 +38,9 @@
 <body>
 <div>
     <h1>Example Domain</h1>
-    <p>This domain is established to be used for illustrative examples in documents. You may use this
-    domain in examples without prior coordination or asking for permission.</p>
-    <p><a href="http://www.iana.org/domains/example">More information...</a></p>
+    <p>This domain is for use in illustrative examples in documents. You may use this
+    domain in literature without prior coordination or asking for permission.</p>
+    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
 </div>
 </body>
 </html>

--- a/main.py
+++ b/main.py
@@ -167,7 +167,7 @@ def add_wishlist(bot, update):
 
     reply_markup = InlineKeyboardMarkup([[cancel_button]])
 
-    add_user_if_new(user)
+    add_user_if_new(User(user.id, user.first_name, user.username, user.language_code))
 
     try:
         url = get_wl_url(text)
@@ -224,7 +224,7 @@ def add_product(bot, update):
 
     reply_markup = InlineKeyboardMarkup([[cancel_button]])
 
-    add_user_if_new(user)
+    add_user_if_new(User(user.id, user.first_name, user.username, user.language_code))
 
     try:
         url = get_p_url(text)


### PR DESCRIPTION
In the add_user_if_new method there was a wrong user object used. Because of this bug you were not able to add a product/wishlist. This commit changes the user object so that it's possible again to add products/wishlists again.