### PR TITLE
HOTFIX: Use continue instead of return

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,7 +210,7 @@ def check_for_price_update(context):
                 core.update_entity_name(entity, new_name)
 
             if old_price == new_price:
-                return
+                continue
 
             entity.price = new_price
             core.update_entity_price(entity, new_price)


### PR DESCRIPTION
In this case we only want to skip further code execution by continuing the loop. Returning is not a good idea here.